### PR TITLE
Fix loading DBD::Firebird::TypeInfo with strict/warnings

### DIFF
--- a/inc/FirebirdMaker.pm
+++ b/inc/FirebirdMaker.pm
@@ -817,7 +817,7 @@ EOT
             $f => {
                 new_path => $n,
                 mangle => sub {
-                    $_[0] =~ s/DBD::Firebird\b/DBD::FirebirdEmbedded/g;
+                    $_[0] =~ s/DBD::Firebird\b(?!::(?:Get|Type|Table)Info)/DBD::FirebirdEmbedded/g;
                     $_[0] =~ s/TestFirebird\b/TestFirebirdEmbedded/g;
                 },
             }

--- a/lib/DBD/Firebird/TypeInfo.pm
+++ b/lib/DBD/Firebird/TypeInfo.pm
@@ -13,13 +13,9 @@ use strict;
 use warnings;
 
 {
-    require Exporter;
-    require DynaLoader;
-    @ISA = qw(Exporter DynaLoader);
-    @EXPORT = qw(type_info_all);
     use DBI qw(:sql_types);
 
-    $type_info_all = [
+    our $type_info_all = [
         {
             TYPE_NAME          =>  0,
             DATA_TYPE          =>  1,

--- a/t/00-base.t
+++ b/t/00-base.t
@@ -11,10 +11,15 @@ BEGIN {
     $^W = 1;
 }
 
-use Test::More tests => 2;
+use Test::More tests => 7;
 
 use_ok('DBI');
 
 use_ok('DBD::Firebird');
+use_ok('DBD::Firebird::GetInfo');
+use_ok('DBD::Firebird::TableInfo');
+use_ok('DBD::Firebird::TableInfo::Basic');
+use_ok('DBD::Firebird::TableInfo::Firebird21');
+use_ok('DBD::Firebird::TypeInfo');
 
 # diag("\$DBI::VERSION=$DBI::VERSION");


### PR DESCRIPTION
Adding strict/warnings to DBD::FireBird::TypeInfo broke it completely.
Remove the extraneous crap and add an 'our' declaration to the one
variable that's actually used.  Also add tests that all the modules
can be loaded.