### PR TITLE
Silence 'Missing argument in sprintf' warning on perl 5.22

### DIFF
--- a/lib/DBD/Firebird/GetInfo.pm
+++ b/lib/DBD/Firebird/GetInfo.pm
@@ -22,6 +22,7 @@ my $sql_ver_fmt = '%02d.%02d.%04d';   # ODBC version string: ##.##.#####
 my $sql_driver_ver;
 {
     no warnings 'uninitialized';
+    no if $] >= 5.022, warnings => 'missing';
     $sql_driver_ver = sprintf $sql_ver_fmt, split (/\./, $DBD::Firebird::VERSION);
 }
 


### PR DESCRIPTION
The warning got split from the `uninitialized` category into its own `missing` category.