### PR TITLE
Added the check for the decimal type - this is the type that is failing.

### DIFF
--- a/t/63-doubles.t
+++ b/t/63-doubles.t
@@ -40,7 +40,8 @@ my $def =<<"DEF";
 CREATE TABLE $table (
     id integer,
     flt float,
-    dbl double precision
+    dbl double precision,
+    deci decimal (18,5)
 )
 DEF
 ok( $dbh->do($def), qq{CREATE TABLE '$table'} );
@@ -51,24 +52,24 @@ ok( $dbh->do($def), qq{CREATE TABLE '$table'} );
 
 my $stmt =<<"END_OF_QUERY";
 INSERT INTO $table (
-    id, flt, dbl
-) VALUES (?, ?, ?)
+    id, flt, dbl, deci
+) VALUES (?, ?, ?, ?)
 END_OF_QUERY
 
 ok(my $insert = $dbh->prepare($stmt), 'PREPARE INSERT');
 
 # Insert positive numbers
 my $id = 1;
-ok($insert->execute( $id++, $_, $_ ), "Inserting $_" ) for @doubles;
+ok($insert->execute( $id++, $_, $_, $_ ), "Inserting $_" ) for @doubles;
 
 # Insert positive numbers
-ok($insert->execute( $id++, -$_, -$_ ), "Inserting -$_" ) for @doubles;
+ok($insert->execute( $id++, -$_, -$_, -$_ ), "Inserting -$_" ) for @doubles;
 
 
 #
 #   Select the values
 #
-ok( my $cursor = $dbh->prepare( qq{SELECT id, flt, dbl FROM $table WHERE id=?} ),
+ok( my $cursor = $dbh->prepare( qq{SELECT id, flt, dbl, deci FROM $table WHERE id=?} ),
     'PREPARE SELECT' );
 
 $id = 0;
@@ -76,14 +77,14 @@ for my $n (@doubles) {
     $id++;
     ok($cursor->execute($id), "EXECUTE SELECT $id ($n)");
     ok((my $res = $cursor->fetchrow_arrayref), "FETCHALL arrayref $id ($n)");
-    cmp_deeply($res, [ $id, num($n, 1e-6), num($n, 1e-6) ], "row $id ($n)");
+    cmp_deeply($res, [ $id, num($n, 1e-6), num($n, 1e-6),num($n, 1e-6) ], "row $id ($n)");
 }
 
 for my $n (@doubles) {
     $id++;
     ok($cursor->execute($id), "EXECUTE SELECT $id (-$n)");
     ok((my $res = $cursor->fetchrow_arrayref), "FETCHALL arrayref $id (-$n)");
-    cmp_deeply($res, [ $id, num(-$n, 1e-6), num(-$n, 1e-6) ], "row $id (-$n)");
+    cmp_deeply($res, [ $id, num(-$n, 1e-6), num(-$n, 1e-6),num(-$n, 1e-6) ], "row $id (-$n)");
 }
 
 


### PR DESCRIPTION
This is the actual failure with the bug https://rt.cpan.org/Public/Bug/Display.html?id=101650
Example output:
t/63-doubles.t .................. 1/?
#   Failed test 'row 10 (-0.4)'
#   at t/63-doubles.t line 87.
# Comparing $data->[3] as a number
#    got : 0.4 ('0.40000')
# expect : -0.4 +/- 1e-06

#   Failed test 'row 11 (-0.6)'
#   at t/63-doubles.t line 87.
# Comparing $data->[3] as a number
#    got : 0.6 ('0.60000')
# expect : -0.6 +/- 1e-06

#   Failed test 'row 12 (-0.8)'
#   at t/63-doubles.t line 87.
# Comparing $data->[3] as a number
#    got : 0.8 ('0.80000')
# expect : -0.8 +/- 1e-06

#   Failed test 'row 13 (-0.95)'
#   at t/63-doubles.t line 87.
# Comparing $data->[3] as a number
#    got : 0.95 ('0.95000')
# expect : -0.95 +/- 1e-06
# Looks like you failed 4 tests of 79.
