### PR TITLE
On macOS: Do not link with Firebird framework if it does not exist.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -292,7 +292,17 @@ SWITCH: {
         last SWITCH;
     };
     $os eq 'darwin' && do {
-        $MakeParams{LDDLFLAGS} = $Config{lddlflags} . " -framework Firebird ";
+        my $framework_dir = dirname $FB::HOME; #"/Library/Frameworks/Firebird.framework";
+        my $framework_name = File::Spec->catfile( $framework_dir, "Firebird");
+        # For some reason, the framework file can be a broken symlink, see issue #??
+        #  We can use -e to check if the symlink is broken:
+        if ( -e $framework_name ) {
+            $MakeParams{LDDLFLAGS} = $Config{lddlflags} . " -framework Firebird ";
+        }
+        else {
+            $MakeParams{LDDLFLAGS} = $Config{lddlflags};
+            $MakeParams{LIBS} = "-L$FB::LIB -l$client_lib ";
+        }
         last SWITCH;
     };
 


### PR DESCRIPTION
Do not link with Firebird framework if it does not exist on macOS.
This (and possibly combined with https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/403) should fix issue #51, but I am not able to test it since I am using Apple M1 chip and the Firebird libraries for version 3 are built for macOS-x86_64.