### PR TITLE
Add missing semicolon to fix C syntax

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1383,7 +1383,7 @@ AV *dbd_st_fetch(SV *sth, imp_sth_t *imp_sth)
 #ifdef sv_setbool
                     sv_setbool(sv, b == FB_TRUE);
 #else
-                    sv_setiv(sv, (b == FB_TRUE) ? 1 : 0)
+                    sv_setiv(sv, (b == FB_TRUE) ? 1 : 0);
 #endif
 #endif
                     break;


### PR DESCRIPTION
Unfortunately, https://github.com/mariuz/perl-dbd-firebird/commit/d93f911421c0f4fe2631b023ef46227fdd412fe8 introduced a syntax mistake due to a missing semicolon which leads on build-time to:

```
dbdimp.c: In function 'ib_st_fetch':
dbdimp.c:1389:21: error: expected ';' before 'break'
 1389 |                     break;
      |                     ^~~~~
```