### PR TITLE
fix typo in revision history

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,7 +5,7 @@ Revision history for Perl extension DBD::Firebird.
 1.37 [2024-05-20]
  * fall back to sv_setiv when sv_setbool is not available (gh#58)
 1.36 [2024-05-19]
- * fix problems with Perl befpre 5.36 and Firebird before 3.0
+ * fix problems with Perl before 5.36 and Firebird before 3.0
    (gh#56 and gh#57)
 1.35 [2024-05-15]
  * ib2sql_type: ignore nullability bit


### PR DESCRIPTION
Just noticed when preparing the 1.38 update for Fedora and EPEL.