### PR TITLE
add (conditional) support for firebird_version via ib_database_info

### DIFF
--- a/Firebird.xs
+++ b/Firebird.xs
@@ -923,6 +923,9 @@ ib_database_info(dbh, ...)
         DB_INFOBUF(ods_version,       1);
         DB_INFOBUF(page_size,         4);
         DB_INFOBUF(version,         257);
+#ifdef isc_info_firebird_version
+		DB_INFOBUF(firebird_version,257);
+#endif
         DB_INFOBUF(db_sql_dialect,    1);
 
         /* environmental characteristics */
@@ -1060,6 +1063,16 @@ ib_database_info(dbh, ...)
                          newSVpvn(++p, slen), 0);
                 break;
             }
+#ifdef isc_info_firebird_version
+            DB_RESBUF_CASEHDR(firebird_version)
+            {
+                ISC_LONG slen;
+                slen = isc_vax_integer(++p, 1);
+                (void)hv_store(RETVAL, keyname, strlen(keyname),
+                         newSVpvn(++p, slen), 0);
+                break;
+            }
+#endif
 #ifdef isc_dpb_sql_dialect
             DB_RESBUF_CASEHDR(db_sql_dialect)
                 (void)hv_store(RETVAL, keyname, strlen(keyname),

--- a/Firebird.xs
+++ b/Firebird.xs
@@ -924,7 +924,7 @@ ib_database_info(dbh, ...)
         DB_INFOBUF(page_size,         4);
         DB_INFOBUF(version,         257);
 #ifdef isc_info_firebird_version
-		DB_INFOBUF(firebird_version,257);
+        DB_INFOBUF(firebird_version,257);
 #endif
         DB_INFOBUF(db_sql_dialect,    1);
 

--- a/t/90-dbinfo.t
+++ b/t/90-dbinfo.t
@@ -39,6 +39,7 @@ my @items = qw/
         ods_version
         page_size
         version
+        firebird_version
         db_sql_dialect
         current_memory
         forced_writes


### PR DESCRIPTION
Adds `firebird_version` handling in `ib_database_info()`, depending on the availability of `isc_info_firebird_version` constant.

While `version` (`isc_info_version`) already exists, that returns a version that is "compatible" with what an Interbase
server would return. For example, Firebird 4.0.5.3140 server returns `LI-V6.3.5.3140 Firebird 4.0`.

With this change, tha hash returned by `$dbh->ib_database_info(qw(firebird_version))` contains a `firebird_version` key with a value of `LI-V4.0.5.3140 Firebird 4.0`.